### PR TITLE
Feat/dvf market data ws

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react-dom": "^16.12.0",
     "react-router-dom": "^5.1.2",
     "styled-components": "^5.0.1",
-    "swagger-ui": "^3.25.0"
+    "swagger-ui": "^3.25.0",
+    "websocket": "^1.0.33"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/src/spec/getEndpoints.js
+++ b/src/spec/getEndpoints.js
@@ -2,7 +2,7 @@ import {forEachEndpoint} from './forEachEndpoint';
 import {getBodyExample} from './getBodyExample';
 import {makeJsCode, makeWsJsCode} from './makeJsCode';
 import {makePythonCode, makeWsPythonCode} from './makePythonCode';
-import {makeCppCode} from './mapeCppCode';
+import {makeCppCode, makeWsCppCode} from './mapeCppCode';
 import {makeCurlCode} from './makeCurlCode';
 
 export function getEndpoints(spec) {
@@ -47,20 +47,22 @@ function getCalls(spec, entry, path, method) {
       language: 'js',
       name: 'JavaScript',
       content: method === 'ws'
-        ? makeWsJsCode(spec, entry, path, method)
+        ? makeWsJsCode(spec, entry, path)
         : makeJsCode(spec, entry, path, method)
     },
     {
       language: 'py',
       name: 'Python 3',
       content: method === 'ws'
-        ? makeWsPythonCode(spec, entry, path, method)
+        ? makeWsPythonCode(spec, entry, path)
         : makePythonCode(spec, entry, path, method),
     },
     {
       language: 'cpp',
       name: 'C++',
-      content: makeCppCode(spec, entry, path, method),
+      content: method === 'ws'
+        ? makeWsCppCode(spec, entry, path)
+        : makeCppCode(spec, entry, path, method)
     },
   ];
 }

--- a/src/spec/getEndpoints.js
+++ b/src/spec/getEndpoints.js
@@ -4,6 +4,7 @@ import {makeJsCode, makeWsJsCode} from './makeJsCode';
 import {makePythonCode, makeWsPythonCode} from './makePythonCode';
 import {makeCppCode, makeWsCppCode} from './mapeCppCode';
 import {makeCurlCode} from './makeCurlCode';
+import {makeWscatCode} from './makeWscatCode';
 
 export function getEndpoints(spec) {
   const endpoints = [];
@@ -13,12 +14,12 @@ export function getEndpoints(spec) {
 
     const responses = getResponses(entry);
     const calls = getCalls(spec, entry, path, method);
-    const curl = makeCurlCode(spec, entry, path, method);
     const parameters = getParameters(entry);
     const body = getBodyExample(entry);
     const responsesDetails = getResponsesDetails(entry);
     const protocol = method === 'ws' ? 'wss' : 'https';
-    endpoints.push({
+
+    const endpoint = {
       method: method.toUpperCase(),
       title: entry.title,
       name: entry.operationId,
@@ -26,12 +27,21 @@ export function getEndpoints(spec) {
       path: `${protocol}://${spec.host}${path}`,
       description: entry.summary, // TODO: markdown?
       calls,
-      curl,
       responses,
       parameters,
       body: body ? JSON.stringify(body, null, 4) : undefined,
       responsesDetails,
-    });
+    };
+
+    if (method === 'ws') {
+      const wscat = makeWscatCode(spec, entry, path);
+      endpoint.wscat = wscat;
+    } else {
+      const curl = makeCurlCode(spec, entry, path, method);
+      endpoint.curl = curl;
+    }
+
+    endpoints.push(endpoint);
   });
   return endpoints;
 }

--- a/src/spec/makeJsCode.js
+++ b/src/spec/makeJsCode.js
@@ -17,7 +17,7 @@ export function makeJsCode(spec, entry, path, method) {
   );
 }
 
-export function makeWsJsCode(spec, entry, path, method) {
+export function makeWsJsCode(spec, entry, path) {
   const queryLine = getQueryLine(entry.parameters);
   const subParams = getWsSubscribeParams(entry.parameters, entry.operationId);
   return (
@@ -93,7 +93,6 @@ function getBody(parameters) {
 
 export function getWsSubscribeParams(parameters, operationId) {
   const param = (parameters || []).filter(x => x.in === 'subscribeMsg');
-  console.log('getWsSubscribeMsg ~ parameters', parameters);
   const channel = (param.find(x => x.name === 'channel') || {})['x-example'];
   const subParams = [
     {name: 'event', value: '\'subscribe\''},

--- a/src/spec/makeJsCode.js
+++ b/src/spec/makeJsCode.js
@@ -95,8 +95,8 @@ export function getWsSubscribeParams(parameters, operationId) {
   const param = (parameters || []).filter(x => x.in === 'subscribeMsg');
   const channel = (param.find(x => x.name === 'channel') || {})['x-example'];
   const subParams = [
-    {name: 'event', value: '\'subscribe\''},
-    {name: 'channel', value: `'${channel}'`},
+    {name: '"event"', value: '"subscribe"'},
+    {name: '"channel"', value: `"${channel}"`},
   ];
   const symbol = (param.find(x => x.name === 'symbol') || {})['x-example'];
 
@@ -104,13 +104,13 @@ export function getWsSubscribeParams(parameters, operationId) {
     case 'WsCandles':
       const type = (param.find(x => x.name === 'type') || {})['x-example'];
       const timeInterval = (param.find(x => x.name === 'timeframe') || {})['x-example'];
-      subParams.push({name: 'key', value: `'${type}:${timeInterval}:${symbol}'`});
+      subParams.push({name: '"key"', value: `"${type}:${timeInterval}:${symbol}"`});
       break;
     case 'WsBook':
-      subParams.push({name: 'symbol', value: `'${symbol}'`});
+      subParams.push({name: '"symbol"', value: `"${symbol}"`});
       break;
     case 'WsTicker':
-      subParams.push({name: 'symbol', value: `'${symbol}'`});
+      subParams.push({name: '"symbol"', value: `"${symbol}"`});
       break;
     default:
       throw new Error('Unknown ws operation');

--- a/src/spec/makeJsCode.js
+++ b/src/spec/makeJsCode.js
@@ -30,8 +30,8 @@ export function makeWsJsCode(spec, entry, path) {
     `  ws.on('message', (msg) => console.log(msg))\n` +
     '\n' +
     '  const subscribeMsg = JSON.stringify({\n' +
-    subParams.map((p) => `    ${p.name}: ${p.value},\n`).join('') +
-    '  } \n' +
+    `${subParams.map((p) => `    ${p.name}: ${p.value}`).join(',\n')}\n` +
+    '  }) \n' +
     '\n' +
     `  ws.on('open', () => ws.send(subscribeMsg))\n` +
     '}'

--- a/src/spec/makePythonCode.js
+++ b/src/spec/makePythonCode.js
@@ -29,7 +29,7 @@ export function makeWsPythonCode(spec, entry, path) {
   return (
     `ws = websocket.WebSocketApp(${url})\n` +
     'ws.on_open = lambda self: self.send(\n' +
-    subParams.map((p) => `  ${p.name}: ${p.value},\n`).join('') +
+      `  '{${subParams.map((p) => `${p.name}:${p.value}`).join(',')}}'\n` +
     ')\n' +
     'ws.on_message = lambda self, evt:  print (evt)'
   );

--- a/src/spec/makePythonCode.js
+++ b/src/spec/makePythonCode.js
@@ -23,7 +23,7 @@ export function makePythonCode(spec, entry, path, method) {
   );
 }
 
-export function makeWsPythonCode(spec, entry, path, method) {
+export function makeWsPythonCode(spec, entry, path) {
   const url = `'wss://${spec.host}/${path}'`;
   const subParams = getWsSubscribeParams(entry.parameters, entry.operationId);
   return (

--- a/src/spec/makeWscatCode.js
+++ b/src/spec/makeWscatCode.js
@@ -1,0 +1,11 @@
+import {getWsSubscribeParams} from './makeJsCode';
+
+export function makeWscatCode(spec, entry, path) {
+  const url = `'wss://${spec.host}/${path}'`;
+  const subParams = getWsSubscribeParams(entry.parameters, entry.operationId);
+
+  const code = `wscat -c ${url}
+  < {"event":"info","version":2,"serverId":"11111111-1111-1111-1111-111111111111","platform":{"status":1}}
+  > {${subParams.map((p) => `${p.name}:${p.value}`)}}`;
+  return code;
+}

--- a/src/spec/mapeCppCode.js
+++ b/src/spec/mapeCppCode.js
@@ -44,7 +44,7 @@ std::cout << response.str() << std::endl;
 }
 
 export function makeWsCppCode(spec, entry, path) {
-  const url = `'wss://${spec.host}/${path}'`;
+  const url = `wss://${spec.host}/${path}`;
   const subParams = getWsSubscribeParams(entry.parameters, entry.operationId);
   return `// Required on Windows
 ix::initNetSystem();
@@ -64,7 +64,7 @@ webSocket.setOnMessageCallback([](const ix::WebSocketMessagePtr& msg)
 // Now that our callback is setup, we can start our background thread and receive messages
 webSocket.start();
 // Send a message to the server (default to TEXT mode)
-webSocket.send("{${subParams.map((p) => ` '${p.name}':${p.value}`)} }");`;
+webSocket.send("{${subParams.map((p) => ` ${p.name}:${p.value}`).toString().replace(/"/g, '\\"')} }");`;
 }
 
 function escapeString(str) {

--- a/src/spec/swagger-overlay.json
+++ b/src/spec/swagger-overlay.json
@@ -1380,7 +1380,7 @@
       "get":{
         "title":"Tickers",
         "summary":"The ticker endpoint provides a high level overview of the state of the market for a specified pair. It shows the current best bid and ask, the last traded price, as well as information on the daily volume and price movement over the last day.",
-        "operationId":"getBfxV2Tickers",
+        "operationId":"getDvfTickers",
         "parameters":[
           {
             "in":"query",

--- a/src/spec/swagger-overlay.json
+++ b/src/spec/swagger-overlay.json
@@ -1376,7 +1376,7 @@
         }
       }
     },
-    "/bfx/v2/tickers":{
+    "/market-data/tickers":{
       "get":{
         "title":"Tickers",
         "summary":"The ticker endpoint provides a high level overview of the state of the market for a specified pair. It shows the current best bid and ask, the last traded price, as well as information on the daily volume and price movement over the last day.",
@@ -1387,8 +1387,8 @@
             "name":"symbols",
             "type":"string",
             "required":true,
-            "description":"Specify the trading pair. A list of symbols can also be provided. In order to retrieve the results of all trading pairs, the symbol “ALL” should be used. symbols = [\"tMKRETH\", \"fUSD\", \"tETHUSD\"]",
-            "x-example":"tMKRETH"
+            "description":"Specify the trading pair. A list of symbols can also be provided. In order to retrieve the results of all trading pairs, the symbol “ALL” should be used. symbols = [\"ZRX:USDT\", \"ETH:USDT\"]",
+            "x-example":"ETH:USDT"
           }
         ],
         "tags":[

--- a/src/spec/swagger-overlay.json
+++ b/src/spec/swagger-overlay.json
@@ -1613,6 +1613,328 @@
           }
         }
       }
+    },
+    "{ws-uid-1}/market-data/ws": {
+      "ws":{
+        "title":"WS Candles",
+        "summary":"The Candles websocket provides OCHL (Open, Close, High, Low) and volume data for the specified trading pair. The endpoint returns initially a snapshot of candles and subsequently sends candle updates.",
+        "operationId":"WsCandles",
+        "parameters":[
+          {
+            "in":"subscribeMsg",
+            "name":"timeframe",
+            "type":"string",
+            "required":true,
+            "description":"Specify time frame. Available values are '1m', '5m', '15m', '30m', '1h', '3h', '6h','12h', '1D','7D', '14D', '1M'.",
+            "x-example":"1m"
+          },
+          {
+            "in":"subscribeMsg",
+            "name":"symbol",
+            "type":"string",
+            "required":true,
+            "description":"Specify the trading pair for which information is required.",
+            "x-example":"ETH:USDT"
+          },
+          {
+            "in":"subscribeMsg",
+            "name":"type",
+            "type":"string",
+            "required":true,
+            "description":"Section for more precise selection. Available values - \"trade\"",
+            "x-example":"trade"
+          },
+          {
+            "in":"subscribeMsg",
+            "name":"event",
+            "type":"string",
+            "required":true,
+            "description":"Specify client event type. Available values - \"subscribe\"",
+            "x-example":"subscribe"
+          },
+          {
+            "in":"subscribeMsg",
+            "name":"channel",
+            "type":"string",
+            "required":true,
+            "description":"Type of channel to subscribe to. Available values - \"candles\"",
+            "x-example":"candles"
+          }
+        ],
+        "tags":[
+          "Market"
+        ],
+        "responses":{
+          "default":{
+            "description":"Returns the last 100 candles by default, but a limit and a start and/or end timestamp can be specified.",
+            "schema":{
+              "type":"array",
+              "items":{
+                "type":"object",
+                "properties": {
+                  "chanId":{
+                    "type":"number",
+                    "description":"Number representing subscription. (First element of root array)",
+                    "example":1
+                  },
+                  "mts":{
+                    "type":"number",
+                    "description":"Millisecond timestamp.",
+                    "example":1573562880000
+                  },
+                  "open":{
+                    "type":"number",
+                    "description":"First execution during the time frame.",
+                    "example":3.0178E-4
+                  },
+                  "close":{
+                    "type":"number",
+                    "description":"Last execution during the time frame.",
+                    "example":3.3105E-4
+                  },
+                  "high":{
+                    "type":"number",
+                    "description":"Highest execution during the time frame.",
+                    "example":3.3105E-4
+                  },
+                  "low":{
+                    "type":"number",
+                    "description":"Lowest execution during the time frame.",
+                    "example":3.0178E-4
+                  },
+                  "volume":{
+                    "type":"number",
+                    "description":"Quantity of symbol traded within the time frame.",
+                    "example":1840.0074507599998
+                  }
+                }
+              }
+            },
+            "examples":{
+              "application/json":[
+                1,
+                [
+                  [
+                    1573562880000,
+                    3.0E-4,
+                    3.0E-4,
+                    3.0E-4,
+                    3.0E-4,
+                    24083.8638948
+                  ],
+                  [
+                    1573562820000,
+                    3.0178E-4,
+                    3.3105E-4,
+                    3.3105E-4,
+                    3.0178E-4,
+                    1840.0074507599998
+                  ]
+                ]
+              ]
+            }
+          }
+        }
+      }
+    },
+    "{ws-uid-2}/market-data/ws":{
+      "ws":{
+        "title":"WS Ticker",
+        "summary":"The ticker endpoint provides a high level overview of the state of the market for a specified pair. It shows the current best bid and ask, the last traded price, as well as information on the daily volume and price movement over the last day.",
+        "operationId":"WsTicker",
+        "parameters":[
+          {
+            "in":"subscribeMsg",
+            "name":"symbol",
+            "type":"string",
+            "required":true,
+            "description":"Specify the trading pair. A list of symbols can also be provided. In order to retrieve the results of all trading pairs, the symbol “ALL” should be used. symbols = [\"MKR:ETH\", \"ETH:USDT\"]",
+            "x-example":"ETH:USDT"
+          },
+          {
+            "in":"subscribeMsg",
+            "name":"event",
+            "type":"string",
+            "required":true,
+            "description":"Specify client event type. Available values - \"subscribe\"",
+            "x-example":"subscribe"
+          },
+          {
+            "in":"subscribeMsg",
+            "name":"channel",
+            "type":"string",
+            "required":true,
+            "description":"Type of channel to subscribe to. Available values - \"ticker\"",
+            "x-example":"ticker"
+          }
+        ],
+        "tags":[
+          "Market"
+        ],
+        "responses":{
+          "default":{
+            "description":"Returns the current best bid and ask, the last traded price, as well as information on the daily volume and price movement over the last day.",
+            "schema":{
+              "type":"array",
+              "items":{
+                "type":"object",
+                "properties":{
+                  "chanId":{
+                    "type":"number",
+                    "description":"Number representing subscription. (First element of root array)",
+                    "example":1
+                  },
+                  "bid":{
+                    "type":"number",
+                    "description":"Price of the most recent highest bid."
+                  },
+                  "bid_size":{
+                    "type":"number",
+                    "description":"Sum of the 25 highest bid sizes."
+                  },
+                  "ask":{
+                    "type":"number",
+                    "description":"Price of the most recent lowest ask price."
+                  },
+                  "ask_size":{
+                    "type":"number",
+                    "description":"Sum of the 25 lowest ask sizes."
+                  },
+                  "daily_change":{
+                    "type":"number",
+                    "description":"Amount that the last price has changed since yesterday."
+                  },
+                  "daily_change_relative":{
+                    "type":"number",
+                    "description":"Relative price change since yesterday (x 100 for percentage change)."
+                  },
+                  "last_price":{
+                    "type":"number",
+                    "description":"Price of the last trade."
+                  },
+                  "volume":{
+                    "type":"number",
+                    "description":"Daily volume."
+                  },
+                  "high":{
+                    "type":"number",
+                    "description":"Daily high."
+                  },
+                  "low":{
+                    "type":"number",
+                    "description":"Daily low."
+                  }
+                }
+              }
+            },
+            "examples":{
+              "application/json":[
+                1,
+                [
+                  8719.7,
+                  34.58126956,
+                  8722.2,
+                  32.51991831,
+                  263.3,
+                  0.0311,
+                  8722.3,
+                  3798.87390501,
+                  8750,
+                  8449.3
+                ]
+              ]
+            }
+          }
+        }
+      }
+    },
+    "{ws-uid-3}/market-data/ws":{
+      "ws":{
+        "title":"WS Orderbook",
+        "summary":"This public endpoint allows to keep track of the state of DeversiFi orderbooks.",
+        "operationId":"WsBook",
+        "parameters":[
+          {
+            "in":"subscribeMsg",
+            "name":"symbol",
+            "type":"string",
+            "required":true,
+            "description":"Specify the trading pair. A list of symbols can also be provided. In order to retrieve the results of all trading pairs, the symbol “ALL” should be used. symbols = [\"MKR:ETH\", \"ETH:USDT\"]",
+            "x-example":"ETH:USDT"
+          },
+          {
+            "in":"subscribeMsg",
+            "name":"event",
+            "type":"string",
+            "required":true,
+            "description":"Specify client event type. Available values - \"subscribe\"",
+            "x-example":"subscribe"
+          },
+          {
+            "in":"subscribeMsg",
+            "name":"channel",
+            "type":"string",
+            "required":true,
+            "description":"Type of channel to subscribe to. Available values - \"book\"",
+            "x-example":"book"
+          }
+        ],
+        "tags":[
+          "Market"
+        ],
+        "responses":{
+          "default":{
+            "description":"Returns a specific order and allows you to keep track of the state of Deversifi order books on a price aggregated basis with customizable precision.",
+            "schema":{
+              "type":"object",
+              "properties":{
+                "chanId":{
+                  "type":"number",
+                  "description":"Number representing subscription. (First element of root array)",
+                  "example":1
+                },
+                "Price":{
+                  "type":"number",
+                  "description":"Specifies the price level for trading."
+                },
+                "Count":{
+                  "type":"number",
+                  "description":"Number of orders at that price level."
+                },
+                "Amount":{
+                  "type":"number",
+                  "description":"Total amount available at that price level."
+                }
+              }
+            },
+            "examples":{
+              "application/json":[
+                1,
+                [
+                  302,
+                  1,
+                  20
+                ],
+                [
+                  168.02,
+                  1,
+                  0.6
+                ],
+                [
+                  167.98,
+                  1,
+                  0.6
+                ],
+                [
+                  167.94,
+                  1,
+                  0.6
+                ]
+              ]
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/spec/tryWsEndpoint.js
+++ b/src/spec/tryWsEndpoint.js
@@ -1,0 +1,61 @@
+import {w3cwebsocket} from 'websocket';
+import {getWsSubscribeParams} from './makeJsCode';
+
+export async function tryWsEndpoint(endpoint, parameterValues, body) {
+  try {
+    const ws = w3cwebsocket(endpoint.path);
+
+    const mergedParams = endpoint.parameters.map((p) => {
+      if (parameterValues[p.name]) { return {...p, 'x-example': parameterValues[p.name]}; }
+      return p;
+    });
+    const wsSubParams = getWsSubscribeParams(mergedParams, endpoint.name);
+    const wsSubMessage = {};
+    wsSubParams.forEach((p) => {
+      // convert to simple strings
+      const key = p.name.replace(/"/g, '');
+      const value = p.value.replace(/"/g, '');
+      wsSubMessage[key] = value;
+    });
+
+    let firstDataReceived;
+    let firstDataError;
+    const waitForData = new Promise((resolve, reject) => {
+      firstDataReceived = resolve;
+      firstDataError = reject;
+      setTimeout(() => { reject(new Error('Request timeout')); }, 10000);
+    });
+
+    ws.onopen = () => {
+      ws.send(JSON.stringify(wsSubMessage));
+    };
+
+    ws.onmessage = (message) => {
+      const parsedData = JSON.parse(message.data);
+
+      if (parsedData['event'] && parsedData['event'] === 'error') {
+        return firstDataError(parsedData['msg']);
+      }
+
+      // skip other informational messages
+      if (parsedData['event']) { return; }
+
+      firstDataReceived(parsedData);
+    };
+
+    ws.onerror = (err) => {
+      firstDataError(err);
+    };
+
+    const message = await waitForData;
+
+    ws.close();
+
+    return [null, {
+      status: 200,
+      body: message,
+    }];
+  } catch (err) {
+    return [err];
+  }
+}

--- a/src/ui/Docs/Endpoint.jsx
+++ b/src/ui/Docs/Endpoint.jsx
@@ -33,7 +33,7 @@ export const Endpoint = ({endpoint}) => {
         <Row isContentFullWidth={isContentFullWidth}>
           <RowItem>
             <ExampleCall calls={calls}/>
-            <TryEndpoint endpoint={endpoint}/>
+            { method !== 'WS' && <TryEndpoint endpoint={endpoint}/> }
           </RowItem>
           <RowItem>
             <ResponseExample responses={responses}/>

--- a/src/ui/Docs/Endpoint.jsx
+++ b/src/ui/Docs/Endpoint.jsx
@@ -33,7 +33,7 @@ export const Endpoint = ({endpoint}) => {
         <Row isContentFullWidth={isContentFullWidth}>
           <RowItem>
             <ExampleCall calls={calls}/>
-            { method !== 'WS' && <TryEndpoint endpoint={endpoint}/> }
+            <TryEndpoint endpoint={endpoint} method={method}/>
           </RowItem>
           <RowItem>
             <ResponseExample responses={responses}/>

--- a/src/ui/Docs/Intro.jsx
+++ b/src/ui/Docs/Intro.jsx
@@ -5,8 +5,8 @@ import docs from '../../assets/docs.svg';
 import tutorials from '../../assets/tutorials.svg';
 import angleIcon from '../../assets/icons/angle-bright.svg';
 import github from '../../assets/github.svg';
-import {Link, GreenLink} from '../common/Link';
-import {Code} from '../common/Code';
+import {GreenLink} from '../common/Link';
+import {CodeInText} from '../common/CodeInText';
 import {List, ListItem} from '../common/List';
 
 export const Intro = (props) => (
@@ -169,18 +169,4 @@ const Text = styled.p`
   font-size: 14px;
   line-height: 150%;
   margin-top: 16px;
-`;
-
-const Note = styled.p`
-  font-family: Lato;
-  font-style: normal;
-  font-weight: bold;
-  font-size: 14px;
-  line-height: 140%;
-  color: #C8C9DA;
-  margin-top: 8px;
-`;
-
-const CodeInText = styled(Code)`
-  margin-left: 8px;
 `;

--- a/src/ui/Docs/TryEndpoint.jsx
+++ b/src/ui/Docs/TryEndpoint.jsx
@@ -3,13 +3,14 @@ import {SectionTitle} from '../common/SectionTitle';
 import {ButtonFullWidth} from '../common/Buttons/Button';
 import {Body} from './Body';
 import {tryEndpoint} from '../../spec/tryEndpoint';
+import {tryWsEndpoint} from '../../spec/tryWsEndpoint';
 import {Parameter} from './Parameter';
 import {ResponseError, Response} from './Response';
 import styled from 'styled-components';
 import {useLayout} from '../common/Layout/LayoutProvider';
 import {PrismCode} from './PrismCode';
 
-export const TryEndpoint = ({endpoint}) => {
+export const TryEndpoint = ({endpoint, method}) => {
   const [parameterValues, setParameterValues] = useState({});
   const [body, setBody] = useState(endpoint.body);
   const [response, setResponse] = useState();
@@ -20,7 +21,12 @@ export const TryEndpoint = ({endpoint}) => {
     setResponse(undefined);
     setError(undefined);
     setLoading(true);
-    const [error, response] = await tryEndpoint(endpoint, parameterValues, body);
+    let error, response;
+    if (method === 'WS') {
+      ([error, response] = await tryWsEndpoint(endpoint, parameterValues, body));
+    } else {
+      ([error, response] = await tryEndpoint(endpoint, parameterValues, body));
+    }
     error && setError(error);
     response && setResponse(response);
     setLoading(false);
@@ -59,13 +65,28 @@ export const TryEndpoint = ({endpoint}) => {
         {response && <Response response={response}/>}
       </Section>
       <div>
-        <Title>cURL</Title>
-        <Pre>
-          <PrismCode
-            language="bash"
-            code={endpoint.curl}
-          />
-        </Pre>
+        { endpoint.curl &&
+          <>
+            <Title>cURL</Title>
+            <Pre>
+              <PrismCode
+                language="bash"
+                code={endpoint.curl}
+              />
+            </Pre>
+          </>
+        }
+        { endpoint.wscat &&
+          <>
+            <Title>wscat</Title>
+            <Pre>
+              <PrismCode
+                language="bash"
+                code={endpoint.wscat}
+              />
+            </Pre>
+          </>
+        }
       </div>
     </Row>
   );

--- a/src/ui/Tutorials/TutorialsSections/LibrariesExamplesSection.jsx
+++ b/src/ui/Tutorials/TutorialsSections/LibrariesExamplesSection.jsx
@@ -2,13 +2,9 @@ import React from 'react';
 import styled from 'styled-components';
 import {TutorialSection} from './TutorialSection';
 import {Text} from '../../common/Text';
-import {Code} from '../../common/Code';
+import {CodeInText} from '../../common/CodeInText';
 import {GreenLink} from '../../common/Link';
 import {List, ListItem} from '../../common/List';
-
-const CodeInText = styled(Code)`
-  margin-left: 8px;
-`;
 
 export const LibrariesExamplesSection = () => (
   <TutorialSection title="Libraries and Examples">

--- a/src/ui/Tutorials/TutorialsSections/RestMarketDataSection.jsx
+++ b/src/ui/Tutorials/TutorialsSections/RestMarketDataSection.jsx
@@ -15,9 +15,9 @@ export const RestMarketDataSection = () => (
     <TutorialSection title="Rest API Market Data">
       <Text>
         Deversifi currently places orders with Bitfinex and market data can be retrieved using Bitfinex public end points.
-        Available symbols for trading are available in in the client config file under: DVF.exchangeSymbols
+        Available symbols for trading are available in in the client config file under: DVF.exchangeSymbols.
         <Bold> Currently market data APIs both websocket and REST are transitioning to a new implementation,
-          thus endpoints are gradually switching to endpoint <CodeInText>/market-data/ws</CodeInText> which use different symbol format</Bold>
+          thus endpoints are gradually switching to endpoint <CodeInText>/market-data/ws</CodeInText> which uses different symbol format</Bold>
       </Text>
     </TutorialSection>
     <SubSection id="Rest API Market Data" className="section">

--- a/src/ui/Tutorials/TutorialsSections/RestMarketDataSection.jsx
+++ b/src/ui/Tutorials/TutorialsSections/RestMarketDataSection.jsx
@@ -17,7 +17,7 @@ export const RestMarketDataSection = () => (
         Deversifi currently places orders with Bitfinex and market data can be retrieved using Bitfinex public end points.
         Available symbols for trading are available in in the client config file under: DVF.exchangeSymbols.
         <Bold> Currently market data APIs both websocket and REST are transitioning to a new implementation,
-          thus endpoints are gradually switching to endpoint <CodeInText>/market-data/ws</CodeInText> which uses different symbol format</Bold>
+          thus endpoints are gradually switching to endpoint <CodeInText>/market-data/</CodeInText> which uses different symbol format.</Bold>
       </Text>
     </TutorialSection>
     <SubSection id="Rest API Market Data" className="section">
@@ -100,7 +100,7 @@ request(url, function(error, response, body) {
         Bitfinex Rest APIs and examples are available here:</Text>
         <List>
           <ListItem>
-            <Text>Tickers: <GreenLink href="https://docs.deversifi.com/docs#getBfxV2Tickers">https://docs.deversifi.com/docs#getBfxV2Tickers</GreenLink></Text>
+            <Text>Tickers: <GreenLink href="https://docs.deversifi.com/docs#getDvfTickers">https://docs.deversifi.com/docs#getDvfTickers</GreenLink></Text>
           </ListItem>
           <ListItem>
             <Text>Candles: <GreenLink href="https://docs.deversifi.com/docs#getBfxV2Candles">https://docs.deversifi.com/docs#getBfxV2Candles</GreenLink></Text>

--- a/src/ui/Tutorials/TutorialsSections/RestMarketDataSection.jsx
+++ b/src/ui/Tutorials/TutorialsSections/RestMarketDataSection.jsx
@@ -6,13 +6,19 @@ import {SubTitle} from '../../common/SubTitle';
 import {List, ListItem} from '../../common/List';
 import {SubSection} from '../../common/SubSection';
 import {PrismCode} from '../../Docs/PrismCode';
-import {Code} from '../../common/Code';
+import {CodeInText} from '../../common/CodeInText';
+import {Bold} from '../../common/Bold';
 import styled from 'styled-components';
 
 export const RestMarketDataSection = () => (
   <>
     <TutorialSection title="Rest API Market Data">
-      <Text>Deversifi currently places orders with Bitfinex and market data can be retrieved using Bitfinex public end points. Available symbols for trading are available in in the client config file under: DVF.exchangeSymbols</Text>
+      <Text>
+        Deversifi currently places orders with Bitfinex and market data can be retrieved using Bitfinex public end points.
+        Available symbols for trading are available in in the client config file under: DVF.exchangeSymbols
+        <Bold> Currently market data APIs both websocket and REST are transitioning to a new implementation,
+          thus endpoints are gradually switching to endpoint <CodeInText>/market-data/ws</CodeInText> which use different symbol format</Bold>
+      </Text>
     </TutorialSection>
     <SubSection id="Rest API Market Data" className="section">
       <SubTitle>Deversifi Client Config</SubTitle>
@@ -44,9 +50,9 @@ export const RestMarketDataSection = () => (
       </CodeWrapper>
       <br></br>
       <SubTitle>Converting Symbol format between Bitfinex and Deversifi:</SubTitle>
-      <Text>Trading symbols in exchangeSymbols are in Deversifi format. Deversifi symbol format is different than Bitfinex symbol format. 
-To make a call to Bitfinex API for Tickers, Candles and Orderbook symbols should be specified in Bitfinex format. 
-The exchange symbols in Deversifi config file use Deversifi format. 
+      <Text>Trading symbols in exchangeSymbols are in Deversifi format. Deversifi symbol format is different than Bitfinex symbol format.
+To make a call to Bitfinex API for Tickers, Candles and Orderbook symbols should be specified in Bitfinex format.
+The exchange symbols in Deversifi config file use Deversifi format.
 <GreenLink href="https://github.com/DeversiFi/dvf-client-js">https://github.com/DeversiFi/dvf-client-js</GreenLink>  can be used to convert between formats.
 <br></br>
 <Text>For example:</Text>

--- a/src/ui/Tutorials/TutorialsSections/WebsocketMarketDataSection.jsx
+++ b/src/ui/Tutorials/TutorialsSections/WebsocketMarketDataSection.jsx
@@ -1,18 +1,24 @@
 import React from 'react';
 import {TutorialSection} from './TutorialSection';
 import {Text} from '../../common/Text';
+import {Bold} from '../../common/Bold';
+import {CodeInText} from '../../common/CodeInText';
 import {GreenLink} from '../../common/Link';
 import {SubTitle} from '../../common/SubTitle';
-import {List, ListItem} from '../../common/List';
 import {SubSection} from '../../common/SubSection';
 import {PrismCode} from '../../Docs/PrismCode';
-import {Code} from '../../common/Code';
 import styled from 'styled-components';
 
 export const WebsocketMarketDataSection = () => (
   <>
     <TutorialSection title="Websocket Market Data">
-      <Text>When designing a trading system to use the DeversiFi APIs, the speed of your reaction to market data is essential. The fastest way to access market data when trading is to subscribe via websocket feeds. This is the same way that the DeversiFi UI shows and updates the order books.</Text>
+      <Text>
+        When designing a trading system to use the DeversiFi APIs, the speed of your reaction to market data is essential.
+        The fastest way to access market data when trading is to subscribe via websocket feeds.
+        This is the same way that the DeversiFi UI shows and updates the order books.
+        <Bold> Currently market data APIs both websocket and REST are transitioning to a new implementation,
+          thus endpoints are gradually switching to endpoint <CodeInText>/market-data/ws</CodeInText> which uses different symbol format</Bold>
+      </Text>
     </TutorialSection>
     <SubSection id="Order Book" className="section">
       <SubTitle>Websocket Order Book</SubTitle>

--- a/src/ui/Tutorials/TutorialsSections/WebsocketMarketDataSection.jsx
+++ b/src/ui/Tutorials/TutorialsSections/WebsocketMarketDataSection.jsx
@@ -22,23 +22,20 @@ export const WebsocketMarketDataSection = () => (
           language="js"
           code={`
             const ws = require('ws')
-const w = new ws('wss://api.deversifi.com/bfx/ws/2')
+const w = new ws('wss://api.deversifi.com/market-data/ws')
 
 w.on('message', (msg) => console.log(msg))
 
 let msg = JSON.stringify({
   event: 'subscribe',
   channel: 'book',
-  symbol: 'tMKRETH'
+  symbol: 'MKR:ETH'
 })
 
 w.on('open', () => w.send(msg))
 `}
         />
       </CodeWrapper>
-      <Text>
-      The fields 'frequency', and 'precision' can also be set when subscribing, with the default being real time and a precision of 5 significant figures.
-      </Text>
       <CodeWrapper>
       <PrismCode
         code={`

--- a/src/ui/Tutorials/TutorialsSections/WebsocketMarketDataSection.jsx
+++ b/src/ui/Tutorials/TutorialsSections/WebsocketMarketDataSection.jsx
@@ -17,7 +17,7 @@ export const WebsocketMarketDataSection = () => (
         The fastest way to access market data when trading is to subscribe via websocket feeds.
         This is the same way that the DeversiFi UI shows and updates the order books.
         <Bold> Currently market data APIs both websocket and REST are transitioning to a new implementation,
-          thus endpoints are gradually switching to endpoint <CodeInText>/market-data/ws</CodeInText> which uses different symbol format</Bold>
+          thus endpoints are gradually switching to endpoint <CodeInText>/market-data/ws</CodeInText> which uses different symbol format.</Bold>
       </Text>
     </TutorialSection>
     <SubSection id="Order Book" className="section">

--- a/src/ui/common/Bold.jsx
+++ b/src/ui/common/Bold.jsx
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export const Bold = styled.b`
+  font-weight: bold;
+`;

--- a/src/ui/common/CodeInText.jsx
+++ b/src/ui/common/CodeInText.jsx
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+import {Code} from './Code';
+
+export const CodeInText = styled(Code)`
+  margin-left: 8px;
+`;

--- a/src/ui/common/Text.jsx
+++ b/src/ui/common/Text.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 
 export const Text = styled.p`

--- a/yarn.lock
+++ b/yarn.lock
@@ -1446,6 +1446,13 @@ buffer@^5.1.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
 
+bufferutil@^4.0.1:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.3.tgz#66724b756bed23cd7c28c4d306d7994f9943cc6b"
+  integrity sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==
+  dependencies:
+    node-gyp-build "^4.2.0"
+
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
@@ -3639,7 +3646,7 @@ is-symbol@^1.0.2:
   dependencies:
     has-symbols "^1.0.1"
 
-is-typedarray@~1.0.0:
+is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
@@ -4232,6 +4239,11 @@ node-forge@^0.7.1:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.6.tgz#fdf3b418aee1f94f0ef642cd63486c77ca9724ac"
   integrity sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==
+
+node-gyp-build@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
+  integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
 
 node-libs-browser@^2.0.0:
   version "2.2.1"
@@ -6564,6 +6576,13 @@ type@^2.0.0:
   resolved "https://registry.yarnpkg.com/type/-/type-2.0.0.tgz#5f16ff6ef2eb44f260494dae271033b29c09a9c3"
   integrity sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==
 
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+  dependencies:
+    is-typedarray "^1.0.0"
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -6691,6 +6710,13 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
+utf-8-validate@^5.0.2:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.4.tgz#72a1735983ddf7a05a43a9c6b67c5ce1c910f9b8"
+  integrity sha512-MEF05cPSq3AwJ2C7B7sHAA6i53vONoZbMGX8My5auEVm6W+dJ2Jd/TZPyGJ5CH42V2XtbI5FD28HeHeqlPzZ3Q==
+  dependencies:
+    node-gyp-build "^4.2.0"
+
 utf8-bytes@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/utf8-bytes/-/utf8-bytes-0.0.1.tgz#116b025448c9b500081cdfbf1f4d6c6c37d8837d"
@@ -6804,6 +6830,18 @@ webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
+websocket@^1.0.33:
+  version "1.0.33"
+  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.33.tgz#407f763fc58e74a3fa41ca3ae5d78d3f5e3b82a5"
+  integrity sha512-XwNqM2rN5eh3G2CUQE3OHZj+0xfdH42+OFK6LdC2yqiC0YU8e5UK0nYre220T0IyyN031V/XOvtHvXozvJYFWA==
+  dependencies:
+    bufferutil "^4.0.1"
+    debug "^2.2.0"
+    es5-ext "^0.10.50"
+    typedarray-to-buffer "^3.1.5"
+    utf-8-validate "^5.0.2"
+    yaeti "^0.0.6"
 
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:
   version "1.0.5"
@@ -6921,6 +6959,11 @@ y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
+yaeti@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
+  integrity sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=
 
 yargs-parser@^15.0.1:
   version "15.0.1"


### PR DESCRIPTION
Changes:
  - Add websocket endpoint descriptions for tickers, books and candles
  - Update REST ticker endpoint
  - Added "try now" for websocket endpoints
  - Updated article "REST API market data" and "Websocket market data" sections: 
      - updated url to "/market-data" where new endpoints exist
      - add warning statement regarding transition to "/market-data"

  