### PR TITLE
Feat/book candle rest endpoints

### DIFF
--- a/src/spec/getEndpoints.js
+++ b/src/spec/getEndpoints.js
@@ -79,12 +79,19 @@ function getCalls(spec, entry, path, method) {
 
 function getResponses(entry) {
   const responses = [];
+  const hasDefault = Object.keys(entry.responses).includes('default');
+
   for (const key in entry.responses) {
     const response = entry.responses[key];
     let example = response.examples && response.examples['application/json'];
     example = example && JSON.stringify(example, null, 2);
+
+    if (hasDefault && key === '200') {
+      continue;
+    }
+
     responses.push({
-      code: key,
+      code: key === '200' ? 'default' : key,
       // TODO: status name
       success: !/^\d+$/.test(key) || key.startsWith('2'),
       example,
@@ -95,6 +102,14 @@ function getResponses(entry) {
 }
 
 function getResponsesDetails(entry) {
+  // TODO: currently docs don't support model $ref,
+  // all default responses are defined manually in overlay
+
+  const hasDefault = Object.keys(entry.responses).includes('default');
+
+  if (!hasDefault) {
+    entry.responses.default = entry.responses['200'];
+  }
   switch (entry.responses.default.schema.type) {
     case 'array':
       return entry.responses.default.schema.items.properties;

--- a/src/spec/index.js
+++ b/src/spec/index.js
@@ -1,5 +1,6 @@
 
 import swaggerData from './swagger-v11--submitted.json';
+import swaggerMarketData from './swagger-market-data.json';
 import swaggerOverlay from './swagger-overlay.json';
 import {preprocess} from './preprocess';
 import merge from 'lodash.merge';
@@ -33,6 +34,6 @@ const conciliation = data => {
 
 export function loadSpec() {
   const spec = conciliation(swaggerData);
-  const fullSpec = merge(spec, swaggerOverlay);
+  const fullSpec = merge(spec, swaggerMarketData, swaggerOverlay);
   return preprocess(fullSpec);
 }

--- a/src/spec/swagger-market-data.json
+++ b/src/spec/swagger-market-data.json
@@ -1,0 +1,295 @@
+{
+  "swagger": "2.0",
+  "host": "api.stg.deversifi.com",
+  "basePath": "/",
+  "schemes": [
+      "http"
+  ],
+  "info": {
+      "title": "Deversifi API documentation",
+      "version": "1.0.0",
+      "description": "dvf-pub-api"
+  },
+  "tags": [],
+  "paths": {
+      "/market-data/tickers": {
+          "get": {
+              "summary": "Returns multiple tickers",
+              "operationId": "getMarketdataTickers",
+              "parameters": [
+                  {
+                      "type": "string",
+                      "description": "Comma separated pairs or ALL",
+                      "name": "symbols",
+                      "in": "query",
+                      "required": true
+                  }
+              ],
+              "tags": [
+                  "Market-data"
+              ],
+              "responses": {
+                  "default": {
+                      "schema": {
+                          "$ref": "#/definitions/tickers"
+                      },
+                      "description": "Successful"
+                  }
+              }
+          }
+      },
+      "/market-data/ticker/{symbol}": {
+          "get": {
+              "summary": "Returns single ticker current snapshot.",
+              "operationId": "getMarketdataTickerSymbol",
+              "parameters": [
+                  {
+                      "type": "string",
+                      "enum": [
+                          "ETH:USDT",
+                          "ZRX:USDT",
+                          "ZRX:ETH",
+                          "BTC:USDT",
+                          "ETH:BTC",
+                          "KON:RAD",
+                          "KON:USDT"
+                      ],
+                      "name": "symbol",
+                      "in": "path",
+                      "required": true
+                  }
+              ],
+              "tags": [
+                  "Market-data"
+              ],
+              "responses": {
+                  "default": {
+                      "schema": {
+                          "$ref": "#/definitions/ticker"
+                      },
+                      "description": "Successful"
+                  }
+              }
+          }
+      },
+      "/market-data/book/{symbol}/{precision}": {
+          "get": {
+              "summary": "Returns current order book snapshot of a requested pair",
+              "operationId": "getMarketdataBookSymbolPrecision",
+              "parameters": [
+                  {
+                      "type": "string",
+                      "enum": [
+                          "ETH:USDT",
+                          "ZRX:USDT",
+                          "ZRX:ETH",
+                          "BTC:USDT",
+                          "ETH:BTC",
+                          "KON:RAD",
+                          "KON:USDT"
+                      ],
+                      "name": "symbol",
+                      "in": "path",
+                      "required": true
+                  },
+                  {
+                      "type": "string",
+                      "enum": [
+                          "P0",
+                          "P1",
+                          "P2",
+                          "P3",
+                          "P4"
+                      ],
+                      "name": "precision",
+                      "in": "path",
+                      "required": true
+                  }
+              ],
+              "tags": [
+                  "Market-data"
+              ],
+              "responses": {
+                  "default": {
+                      "schema": {
+                          "$ref": "#/definitions/orderbook"
+                      },
+                      "description": "Successful"
+                  }
+              }
+          }
+      },
+      "/market-data/candles/{key}/{section}": {
+          "get": {
+              "summary": "Returns last or history of candles between start and end limited by limit",
+              "operationId": "getMarketdataCandlesKeySection",
+              "parameters": [
+                  {
+                      "type": "string",
+                      "name": "key",
+                      "in": "path",
+                      "required": true
+                  },
+                  {
+                      "type": "string",
+                      "enum": [
+                          "last",
+                          "hist"
+                      ],
+                      "name": "section",
+                      "in": "path",
+                      "required": true
+                  },
+                  {
+                      "type": "string",
+                      "format": "date",
+                      "description": "Started date of candle period. REQUIRED if section is set to \"hist\"",
+                      "name": "start",
+                      "in": "query"
+                  },
+                  {
+                      "type": "string",
+                      "format": "date",
+                      "description": "End date of candle period. REQUIRED if section is set to \"hist\"",
+                      "name": "end",
+                      "in": "query"
+                  },
+                  {
+                      "type": "number",
+                      "description": "Limit number of candles returned. Default is 240, max is 10000",
+                      "default": 240,
+                      "minimum": 1,
+                      "maximum": 10000,
+                      "name": "limit",
+                      "in": "query"
+                  }
+              ],
+              "tags": [
+                  "Market-data"
+              ],
+              "responses": {
+                  "default": {
+                      "schema": {
+                          "$ref": "#/definitions/candles"
+                      },
+                      "description": "Successful"
+                  }
+              }
+          }
+      }
+  },
+  "definitions": {
+      "Model1": {
+          "type": "array",
+          "items": {
+              "type": "string",
+              "description": "Requested pair",
+              "example": "ETH:USDT"
+          }
+      },
+      "tickers": {
+          "type": "array",
+          "example": [
+              [
+                  "ETH:USDT",
+                  182.02,
+                  0,
+                  184.23,
+                  0,
+                  0,
+                  0,
+                  199.06,
+                  147.046,
+                  0,
+                  0
+              ]
+          ],
+          "items": {
+              "$ref": "#/definitions/Model1"
+          }
+      },
+      "ticker": {
+          "type": "array",
+          "example": [
+              182.02,
+              0,
+              184.23,
+              0,
+              0,
+              0,
+              199.06,
+              147.046,
+              0,
+              0
+          ],
+          "items": {
+              "type": "number",
+              "description": "Current highest bid",
+              "example": 1
+          }
+      },
+      "Model2": {
+          "type": "array",
+          "items": {
+              "type": "number",
+              "description": "Order price",
+              "example": 100.12
+          }
+      },
+      "orderbook": {
+          "type": "array",
+          "example": [
+              [
+                  182.02,
+                  1,
+                  0.5
+              ],
+              [
+                  184.23,
+                  2,
+                  3
+              ],
+              [
+                  199.06,
+                  2,
+                  -2
+              ]
+          ],
+          "items": {
+              "$ref": "#/definitions/Model2"
+          }
+      },
+      "candle": {
+          "type": "array",
+          "items": {
+              "type": "number",
+              "description": "Timestamp",
+              "example": 1611233460000
+          }
+      },
+      "candles": {
+          "type": "array",
+          "example": [
+              [
+                  1611233580000,
+                  2e-7,
+                  2e-7,
+                  2e-7,
+                  2e-7,
+                  0.04
+              ],
+              [
+                  1611233460000,
+                  0.0000054,
+                  0.0000054,
+                  0.0000054,
+                  0.0000054,
+                  0.04
+              ]
+          ],
+          "items": {
+              "$ref": "#/definitions/candle"
+          }
+      }
+  }
+}

--- a/src/spec/swagger-market-data.json
+++ b/src/spec/swagger-market-data.json
@@ -1,295 +1,295 @@
 {
-  "swagger": "2.0",
-  "host": "api.stg.deversifi.com",
-  "basePath": "/",
-  "schemes": [
-      "http"
-  ],
-  "info": {
-      "title": "Deversifi API documentation",
-      "version": "1.0.0",
-      "description": "dvf-pub-api"
-  },
-  "tags": [],
-  "paths": {
-      "/market-data/tickers": {
-          "get": {
-              "summary": "Returns multiple tickers",
-              "operationId": "getMarketdataTickers",
-              "parameters": [
-                  {
-                      "type": "string",
-                      "description": "Comma separated pairs or ALL",
-                      "name": "symbols",
-                      "in": "query",
-                      "required": true
-                  }
-              ],
-              "tags": [
-                  "Market-data"
-              ],
-              "responses": {
-                  "default": {
-                      "schema": {
-                          "$ref": "#/definitions/tickers"
-                      },
-                      "description": "Successful"
-                  }
-              }
-          }
-      },
-      "/market-data/ticker/{symbol}": {
-          "get": {
-              "summary": "Returns single ticker current snapshot.",
-              "operationId": "getMarketdataTickerSymbol",
-              "parameters": [
-                  {
-                      "type": "string",
-                      "enum": [
-                          "ETH:USDT",
-                          "ZRX:USDT",
-                          "ZRX:ETH",
-                          "BTC:USDT",
-                          "ETH:BTC",
-                          "KON:RAD",
-                          "KON:USDT"
-                      ],
-                      "name": "symbol",
-                      "in": "path",
-                      "required": true
-                  }
-              ],
-              "tags": [
-                  "Market-data"
-              ],
-              "responses": {
-                  "default": {
-                      "schema": {
-                          "$ref": "#/definitions/ticker"
-                      },
-                      "description": "Successful"
-                  }
-              }
-          }
-      },
-      "/market-data/book/{symbol}/{precision}": {
-          "get": {
-              "summary": "Returns current order book snapshot of a requested pair",
-              "operationId": "getMarketdataBookSymbolPrecision",
-              "parameters": [
-                  {
-                      "type": "string",
-                      "enum": [
-                          "ETH:USDT",
-                          "ZRX:USDT",
-                          "ZRX:ETH",
-                          "BTC:USDT",
-                          "ETH:BTC",
-                          "KON:RAD",
-                          "KON:USDT"
-                      ],
-                      "name": "symbol",
-                      "in": "path",
-                      "required": true
-                  },
-                  {
-                      "type": "string",
-                      "enum": [
-                          "P0",
-                          "P1",
-                          "P2",
-                          "P3",
-                          "P4"
-                      ],
-                      "name": "precision",
-                      "in": "path",
-                      "required": true
-                  }
-              ],
-              "tags": [
-                  "Market-data"
-              ],
-              "responses": {
-                  "default": {
-                      "schema": {
-                          "$ref": "#/definitions/orderbook"
-                      },
-                      "description": "Successful"
-                  }
-              }
-          }
-      },
-      "/market-data/candles/{key}/{section}": {
-          "get": {
-              "summary": "Returns last or history of candles between start and end limited by limit",
-              "operationId": "getMarketdataCandlesKeySection",
-              "parameters": [
-                  {
-                      "type": "string",
-                      "name": "key",
-                      "in": "path",
-                      "required": true
-                  },
-                  {
-                      "type": "string",
-                      "enum": [
-                          "last",
-                          "hist"
-                      ],
-                      "name": "section",
-                      "in": "path",
-                      "required": true
-                  },
-                  {
-                      "type": "string",
-                      "format": "date",
-                      "description": "Started date of candle period. REQUIRED if section is set to \"hist\"",
-                      "name": "start",
-                      "in": "query"
-                  },
-                  {
-                      "type": "string",
-                      "format": "date",
-                      "description": "End date of candle period. REQUIRED if section is set to \"hist\"",
-                      "name": "end",
-                      "in": "query"
-                  },
-                  {
-                      "type": "number",
-                      "description": "Limit number of candles returned. Default is 240, max is 10000",
-                      "default": 240,
-                      "minimum": 1,
-                      "maximum": 10000,
-                      "name": "limit",
-                      "in": "query"
-                  }
-              ],
-              "tags": [
-                  "Market-data"
-              ],
-              "responses": {
-                  "default": {
-                      "schema": {
-                          "$ref": "#/definitions/candles"
-                      },
-                      "description": "Successful"
-                  }
-              }
-          }
-      }
-  },
-  "definitions": {
-      "Model1": {
-          "type": "array",
-          "items": {
-              "type": "string",
-              "description": "Requested pair",
-              "example": "ETH:USDT"
-          }
-      },
-      "tickers": {
-          "type": "array",
-          "example": [
-              [
-                  "ETH:USDT",
-                  182.02,
-                  0,
-                  184.23,
-                  0,
-                  0,
-                  0,
-                  199.06,
-                  147.046,
-                  0,
-                  0
-              ]
-          ],
-          "items": {
-              "$ref": "#/definitions/Model1"
-          }
-      },
-      "ticker": {
-          "type": "array",
-          "example": [
-              182.02,
-              0,
-              184.23,
-              0,
-              0,
-              0,
-              199.06,
-              147.046,
-              0,
-              0
-          ],
-          "items": {
-              "type": "number",
-              "description": "Current highest bid",
-              "example": 1
-          }
-      },
-      "Model2": {
-          "type": "array",
-          "items": {
-              "type": "number",
-              "description": "Order price",
-              "example": 100.12
-          }
-      },
-      "orderbook": {
-          "type": "array",
-          "example": [
-              [
-                  182.02,
-                  1,
-                  0.5
-              ],
-              [
-                  184.23,
-                  2,
-                  3
-              ],
-              [
-                  199.06,
-                  2,
-                  -2
-              ]
-          ],
-          "items": {
-              "$ref": "#/definitions/Model2"
-          }
-      },
-      "candle": {
-          "type": "array",
-          "items": {
-              "type": "number",
-              "description": "Timestamp",
-              "example": 1611233460000
-          }
-      },
-      "candles": {
-          "type": "array",
-          "example": [
-              [
-                  1611233580000,
-                  2e-7,
-                  2e-7,
-                  2e-7,
-                  2e-7,
-                  0.04
-              ],
-              [
-                  1611233460000,
-                  0.0000054,
-                  0.0000054,
-                  0.0000054,
-                  0.0000054,
-                  0.04
-              ]
-          ],
-          "items": {
-              "$ref": "#/definitions/candle"
-          }
-      }
-  }
+    "swagger": "2.0",
+    "host": "api.stg.deversifi.com",
+    "basePath": "/",
+    "schemes": [
+        "http"
+    ],
+    "info": {
+        "title": "Deversifi API documentation",
+        "version": "1.0.0",
+        "description": "dvf-pub-api"
+    },
+    "tags": [],
+    "paths": {
+        "/market-data/tickers": {
+            "get": {
+                "summary": "Returns multiple tickers",
+                "operationId": "getMarketdataTickers",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Comma separated pairs or ALL",
+                        "name": "symbols",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Market"
+                ],
+                "responses": {
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/tickers"
+                        },
+                        "description": "Successful"
+                    }
+                }
+            }
+        },
+        "/market-data/ticker/{symbol}": {
+            "get": {
+                "summary": "Returns single ticker current snapshot.",
+                "operationId": "getMarketdataTickerSymbol",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "enum": [
+                            "ETH:USDT",
+                            "ZRX:USDT",
+                            "ZRX:ETH",
+                            "BTC:USDT",
+                            "ETH:BTC",
+                            "KON:RAD",
+                            "KON:USDT"
+                        ],
+                        "name": "symbol",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Market"
+                ],
+                "responses": {
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/ticker"
+                        },
+                        "description": "Successful"
+                    }
+                }
+            }
+        },
+        "/market-data/book/{symbol}/{precision}": {
+            "get": {
+                "summary": "Returns current order book snapshot of a requested pair",
+                "operationId": "getMarketdataBookSymbolPrecision",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "enum": [
+                            "ETH:USDT",
+                            "ZRX:USDT",
+                            "ZRX:ETH",
+                            "BTC:USDT",
+                            "ETH:BTC",
+                            "KON:RAD",
+                            "KON:USDT"
+                        ],
+                        "name": "symbol",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "enum": [
+                            "P0",
+                            "P1",
+                            "P2",
+                            "P3",
+                            "P4"
+                        ],
+                        "name": "precision",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Market"
+                ],
+                "responses": {
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/orderbook"
+                        },
+                        "description": "Successful"
+                    }
+                }
+            }
+        },
+        "/market-data/candles/{key}/{section}": {
+            "get": {
+                "summary": "Returns last or history of candles between start and end limited by limit",
+                "operationId": "getMarketdataCandlesKeySection",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "name": "key",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "enum": [
+                            "last",
+                            "hist"
+                        ],
+                        "name": "section",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Started date of candle period. REQUIRED if section is set to \"hist\"",
+                        "name": "start",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "format": "date",
+                        "description": "End date of candle period. REQUIRED if section is set to \"hist\"",
+                        "name": "end",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "Limit number of candles returned. Default is 240, max is 10000",
+                        "default": 240,
+                        "minimum": 1,
+                        "maximum": 10000,
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "tags": [
+                    "Market"
+                ],
+                "responses": {
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/candles"
+                        },
+                        "description": "Successful"
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Model1": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "description": "Requested pair",
+                "example": "ETH:USDT"
+            }
+        },
+        "tickers": {
+            "type": "array",
+            "example": [
+                [
+                    "ETH:USDT",
+                    182.02,
+                    0,
+                    184.23,
+                    0,
+                    0,
+                    0,
+                    199.06,
+                    147.046,
+                    0,
+                    0
+                ]
+            ],
+            "items": {
+                "$ref": "#/definitions/Model1"
+            }
+        },
+        "ticker": {
+            "type": "array",
+            "example": [
+                182.02,
+                0,
+                184.23,
+                0,
+                0,
+                0,
+                199.06,
+                147.046,
+                0,
+                0
+            ],
+            "items": {
+                "type": "number",
+                "description": "Current highest bid",
+                "example": 1
+            }
+        },
+        "Model2": {
+            "type": "array",
+            "items": {
+                "type": "number",
+                "description": "Order price",
+                "example": 100.12
+            }
+        },
+        "orderbook": {
+            "type": "array",
+            "example": [
+                [
+                    182.02,
+                    1,
+                    0.5
+                ],
+                [
+                    184.23,
+                    2,
+                    3
+                ],
+                [
+                    199.06,
+                    2,
+                    -2
+                ]
+            ],
+            "items": {
+                "$ref": "#/definitions/Model2"
+            }
+        },
+        "candle": {
+            "type": "array",
+            "items": {
+                "type": "number",
+                "description": "Timestamp",
+                "example": 1611233460000
+            }
+        },
+        "candles": {
+            "type": "array",
+            "example": [
+                [
+                    1611233580000,
+                    2e-7,
+                    2e-7,
+                    2e-7,
+                    2e-7,
+                    0.04
+                ],
+                [
+                    1611233460000,
+                    0.0000054,
+                    0.0000054,
+                    0.0000054,
+                    0.0000054,
+                    0.04
+                ]
+            ],
+            "items": {
+                "$ref": "#/definitions/candle"
+            }
+        }
+    }
 }

--- a/src/spec/swagger-market-data.json
+++ b/src/spec/swagger-market-data.json
@@ -162,6 +162,17 @@
                         "maximum": 10000,
                         "name": "limit",
                         "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "if = 1 it sorts results returned with old > new",
+                        "default": -1,
+                        "enum": [
+                            1,
+                            -1
+                        ],
+                        "name": "sort",
+                        "in": "query"
                     }
                 ],
                 "tags": [

--- a/src/spec/swagger-overlay.json
+++ b/src/spec/swagger-overlay.json
@@ -1612,8 +1612,16 @@
             "name":"end",
             "type":"string",
             "required":false,
-            "description":"Filter end (time since epoch in ms). Only when section is 'hist'",
+            "description":"Filter end (time since epoch in ms). Only when section is 'hist' Defaults to now.",
             "x-example":"1577923200000"
+          },
+          {
+            "in":"query",
+            "name":"sort",
+            "type":"number",
+            "required":false,
+            "description":"if = 1 it sorts results returned with old > new",
+            "x-example":-1
           }
         ],
         "tags":[

--- a/src/spec/swagger-overlay.json
+++ b/src/spec/swagger-overlay.json
@@ -1306,7 +1306,7 @@
       "get":{
         "title":"Orderbook",
         "summary":"This public endpoint allows to keep track of the state of DeversiFi orderbooks on a price aggregated basis with customizable precision. Raw books can be retrieved by using precision R0.",
-        "operationId":"getBfxV2Book",
+        "operationId":"getDvfBook",
         "parameters":[
           {
             "in":"path",

--- a/src/spec/swagger-overlay.json
+++ b/src/spec/swagger-overlay.json
@@ -1302,7 +1302,7 @@
         }
       }
     },
-    "/bfx/v2/book/{Symbol}/{Precision}":{
+    "/market-data/book/{symbol}/{precision}":{
       "get":{
         "title":"Orderbook",
         "summary":"This public endpoint allows to keep track of the state of DeversiFi orderbooks on a price aggregated basis with customizable precision. Raw books can be retrieved by using precision R0.",
@@ -1379,7 +1379,7 @@
     "/market-data/tickers":{
       "get":{
         "title":"Tickers",
-        "summary":"The ticker endpoint provides a high level overview of the state of the market for a specified pair. It shows the current best bid and ask, the last traded price, as well as information on the daily volume and price movement over the last day.",
+        "summary":"The ticker endpoint provides a high level overview of the state of the market for a specified pairs. It shows the current best bid and ask, the last traded price, as well as information on the daily volume and price movement over the last day.",
         "operationId":"getDvfTickers",
         "parameters":[
           {
@@ -1452,7 +1452,7 @@
             "examples":{
               "application/json":[
                 [
-                  "tBTCUSD",
+                  "BTC:USD",
                   8719.7,
                   34.58126956,
                   8722.2,
@@ -1465,7 +1465,7 @@
                   8449.3
                 ],
                 [
-                  "tLTCUSD",
+                  "LTC:USD",
                   57.875,
                   1297.95111409,
                   57.931,
@@ -1483,27 +1483,105 @@
         }
       }
     },
-    "/bfx/v2/candles/trade:{timeframe}:{symbol}/{section}":{
+    "/market-data/ticker/{symbol}": {
+      "get":{
+        "title":"Ticker",
+        "summary":"The ticker endpoint provides a high level overview of the state of the market for a specified pair. It shows the current best bid and ask, the last traded price, as well as information on the daily volume and price movement over the last day.",
+        "operationId":"getDvfTicker",
+        "parameters":[
+          {
+            "in":"query",
+            "name":"symbols",
+            "type":"string",
+            "required":true,
+            "description":"Specify the trading pair. A list of symbols can also be provided. In order to retrieve the results of all trading pairs, the symbol “ALL” should be used. symbols = [\"ZRX:USDT\", \"ETH:USDT\"]",
+            "x-example":"ETH:USDT"
+          }
+        ],
+        "responses":{
+          "default":{
+            "description":"Returns the current best bid and ask, the last traded price, as well as information on the daily volume and price movement over the last day.",
+            "schema":{
+              "type":"array",
+              "items":{
+                "type":"object",
+                "properties":{
+                  "bid":{
+                    "type":"number",
+                    "description":"Price of the most recent highest bid."
+                  },
+                  "bid_size":{
+                    "type":"number",
+                    "description":"Sum of the 25 highest bid sizes."
+                  },
+                  "ask":{
+                    "type":"number",
+                    "description":"Price of the most recent lowest ask price."
+                  },
+                  "ask_size":{
+                    "type":"number",
+                    "description":"Sum of the 25 lowest ask sizes."
+                  },
+                  "daily_change":{
+                    "type":"number",
+                    "description":"Amount that the last price has changed since yesterday."
+                  },
+                  "daily_change_relative":{
+                    "type":"number",
+                    "description":"Relative price change since yesterday (x 100 for percentage change)."
+                  },
+                  "last_price":{
+                    "type":"number",
+                    "description":"Price of the last trade."
+                  },
+                  "volume":{
+                    "type":"number",
+                    "description":"Daily volume."
+                  },
+                  "high":{
+                    "type":"number",
+                    "description":"Daily high."
+                  },
+                  "low":{
+                    "type":"number",
+                    "description":"Daily low."
+                  }
+                }
+              }
+            },
+            "examples":{
+              "application/json":[
+                [
+                  8719.7,
+                  34.58126956,
+                  8722.2,
+                  32.51991831,
+                  263.3,
+                  0.0311,
+                  8722.3,
+                  3798.87390501,
+                  8750,
+                  8449.3
+                ]
+              ]
+            }
+          }
+        }
+      }
+    },
+    "/market-data/candles/{key}/{section}":{
       "get":{
         "title":"Candles",
         "summary":"The Candles endpoint provides OCHL (Open, Close, High, Low) and volume data for the specified funding currency or trading pair. The endpoint returns the last 100 candles by default, but a limit and a start and/or end timestamp can be specified.",
-        "operationId":"getBfxV2Candles",
+        "operationId":"getDvfCandles",
         "parameters":[
           {
             "in":"path",
-            "name":"timeframe",
+            "name":"key",
             "type":"string",
             "required":true,
-            "description":"Specify time frame. Available values are '1m', '5m', '15m', '30m', '1h', '3h', '6h','12h', '1D','7D', '14D', '1M'.",
-            "x-example":"1m"
-          },
-          {
-            "in":"path",
-            "name":"symbol",
-            "type":"string",
-            "required":true,
-            "description":"Specify the trading pair for which information is required.",
-            "x-example":"tETHUSD"
+            "description":"Is a group of variables defining candles key. First param currently only supports 'trade'. Second param is time frame. Available values are '1m', '5m', '15m', '30m', '1h', '3h', '6h','12h', '1D','7D', '14D', '1M'. And third is the trading pair for which information is required.",
+            "x-example":"trade:1m:ETH:USDT"
           },
           {
             "in":"path",
@@ -1518,7 +1596,7 @@
             "name":"limit",
             "type":"number",
             "required":false,
-            "description":"Limits the number of results.",
+            "description":"Limits the number of results. Max 10000",
             "x-example":10
           },
           {
@@ -1526,7 +1604,7 @@
             "name":"start",
             "type":"string",
             "required":false,
-            "description":"Filter start (time since epoch in ms).",
+            "description":"Filter start (time since epoch in ms). Only when section is 'hist'",
             "x-example":"1517923200000"
           },
           {
@@ -1534,16 +1612,8 @@
             "name":"end",
             "type":"string",
             "required":false,
-            "description":"Filter end (time since epoch in ms).",
+            "description":"Filter end (time since epoch in ms). Only when section is 'hist'",
             "x-example":"1577923200000"
-          },
-          {
-            "in":"query",
-            "name":"sort",
-            "type":"number",
-            "required":false,
-            "description":"Determines if the results should be sorted. If = 1, it sorts results returned with old > new.",
-            "x-example":1
           }
         ],
         "tags":[

--- a/src/spec/swagger-v11--submitted.json
+++ b/src/spec/swagger-v11--submitted.json
@@ -113,7 +113,7 @@
             "schema":{
               "$ref":"#/definitions/User24HoursVolumeResponse"
             },
-            "description": "Returns the overall trading volume details of a specific address for all tokens in USD as well as the trading volume per trading pair fot the last 24 hours.",
+            "description": "Returns the overall trading volume details of a specific address for all tokens in USD as well as the trading volume per trading pair fot the last 24 hours."
           }
         }
       }
@@ -1259,7 +1259,7 @@
         "signature": {
           "type": "string",
           "description": "The signature obtained by signing the nonce with your private ethereum key.",
-          "example": "0x494a2c166f95518dcf5a9484fcb702a454382f281f96ba41639fe3a2af279fdc1e3b4e5aa2f585a9a40fb5aaabf10b5390ed5592d502c7799a261f81219491f001",
+          "example": "0x494a2c166f95518dcf5a9484fcb702a454382f281f96ba41639fe3a2af279fdc1e3b4e5aa2f585a9a40fb5aaabf10b5390ed5592d502c7799a261f81219491f001"
         },
         "token":{
           "type":"string",
@@ -1753,7 +1753,7 @@
           "type": "string",
           "description": "Canceled status.",
           "example": true
-        },
+        }
       }
     },
     "starkPublicKey":{

--- a/src/ui/Tutorials/TutorialsSections/DevelopmentEnvironmentsSection.jsx
+++ b/src/ui/Tutorials/TutorialsSections/DevelopmentEnvironmentsSection.jsx
@@ -11,16 +11,16 @@ export const DevelopmentEnvironmentsSection = () => (
     <List>
       <ListItem>Trading base url: <Code>https://api.deversifi.com/v1/trading/</Code></ListItem>
       <ListItem>Public volume data base url: <Code>https://api.deversifi.com/v1/pub/</Code></ListItem>
-      <ListItem>Price data base url: <Code>https://api.deversifi.com/bfx/v2/</Code></ListItem>
-      <ListItem>Price data websocket base url: <Code>https://api.deversifi.com/bfx/ws/2/</Code></ListItem>
+      <ListItem>Price data base url: <Code>https://api.deversifi.com/market-data/</Code></ListItem>
+      <ListItem>Price data websocket base url: <Code>https://api.deversifi.com/market-data/ws/</Code></ListItem>
     </List>
     <Text>A staging environment which mirrors the live version can be found on app.stg.deversifi.com and is connected to the Ropsten testnet </Text>
     <Text>The base URL for requests is <Code>https://api.stg.deversifi.com</Code></Text>
     <List>
       <ListItem>Trading base url: <Code>https://api.stg.deversifi.com/v1/trading/</Code></ListItem>
       <ListItem>Public volume data base url: <Code>https://api.stg.deversifi.com/v1/pub/</Code></ListItem>
-      <ListItem>Price data base url: <Code>https://api.stg.deversifi.com/bfx/v2/</Code></ListItem>
-      <ListItem>Price data websocket base url: <Code>https://api.stg.deversifi.com/bfx/ws/2/</Code></ListItem>
+      <ListItem>Price data base url: <Code>https://api.stg.deversifi.com/market-data/</Code></ListItem>
+      <ListItem>Price data websocket base url: <Code>https://api.stg.deversifi.com/market-data/ws/</Code></ListItem>
     </List>
     <Text>A faucet for Ropsten ETH for testing purposes - <Code>https://faucet.ropsten.be/</Code></Text>
   </TutorialSection>

--- a/src/ui/Tutorials/TutorialsSections/RestMarketDataSection.jsx
+++ b/src/ui/Tutorials/TutorialsSections/RestMarketDataSection.jsx
@@ -103,10 +103,10 @@ request(url, function(error, response, body) {
             <Text>Tickers: <GreenLink href="https://docs.deversifi.com/docs#getDvfTickers">https://docs.deversifi.com/docs#getDvfTickers</GreenLink></Text>
           </ListItem>
           <ListItem>
-            <Text>Candles: <GreenLink href="https://docs.deversifi.com/docs#getBfxV2Candles">https://docs.deversifi.com/docs#getBfxV2Candles</GreenLink></Text>
+            <Text>Candles: <GreenLink href="https://docs.deversifi.com/docs#getDvfCandles">https://docs.deversifi.com/docs#getDvfCandles</GreenLink></Text>
           </ListItem>
           <ListItem>
-            <Text>Orderbook: <GreenLink href="https://docs.deversifi.com/docs#getBfxV2Book">https://docs.deversifi.com/docs#getBfxV2Book</GreenLink></Text>
+            <Text>Orderbook: <GreenLink href="https://docs.deversifi.com/docs#getDvfBook">https://docs.deversifi.com/docs#getDvfBook</GreenLink></Text>
           </ListItem>
         </List>
     </SubSection>


### PR DESCRIPTION
Add updated endpoint descriptions for /book /ticker /tickers /candles endpoints. Also added porting from swagger 200 -> default endpoint. Since currently all documentation is expected to have a default response. 