### PR TITLE
Remove invalid description, ws ticker only supports one market

### DIFF
--- a/src/spec/swagger-overlay.json
+++ b/src/spec/swagger-overlay.json
@@ -2352,7 +2352,7 @@
             "name":"symbol",
             "type":"string",
             "required":true,
-            "description":"Specify the trading pair. A list of symbols can also be provided. In order to retrieve the results of all trading pairs, the symbol “ALL” should be used. symbols = [\"MKR:ETH\", \"ETH:USDT\"]",
+            "description":"Specify the trading pair.",
             "x-example":"ETH:USDT"
           },
           {


### PR DESCRIPTION
[Update WS ticker API docs](https://app.asana.com/0/1165477653959782/1200559610721496)

Market data websocket ticker only supports one symbol